### PR TITLE
New API Proposal Device_Volume_indicator.md

### DIFF
--- a/documentation/API proposals/APIProposa_Device_Volume.md
+++ b/documentation/API proposals/APIProposa_Device_Volume.md
@@ -1,0 +1,10 @@
+| **Field** | Description |
+ | ---- | ----- |
+ | API family name |Device Data Volume |
+ | API family owner | Deutsche Telekom (Noel Wirzius)|
+ | API summary | This API offers detailed insights into the customer's data usage status, including whether they have remaining data volume available and their current position within that volume allocation. It accurately determines whether the customer is nearing the beginning or the end of their allocated data volume, providing valuable information for managing data usage efficiently.|
+ | Technical viability | The API should get information for a dedicated Sim-Card and also offer this in a subscription mode. The return value should not be a fixed value more an estimated indicator  (e.g. <200mb, <1Gb ...) |
+ | Commercial viability | This API was requested by different content providers. It helps them to get more insights, how to deliver their traffic. | NO |
+ | Validated in lab/productive environments? | Yes |
+ | Validated with operators? | Yes |
+ | Supporters in API Backlog Working Group | |

--- a/documentation/API proposals/APIProposa_Device_Volume.md
+++ b/documentation/API proposals/APIProposa_Device_Volume.md
@@ -7,4 +7,4 @@
  | Commercial viability | This API was requested by different content providers. It helps them to get more insights, how to deliver their traffic. | NO |
  | Validated in lab/productive environments? | Yes |
  | Validated with operators? | Yes |
- | Supporters in API Backlog Working Group | |
+ | Supporters in API Backlog Working Group | Vodafone, Vonage, Deutsche Telekom |


### PR DESCRIPTION
| **Field** | Description |
 | ---- | ----- |
 | API family name |Device Data Volume |
 | API family owner | Deutsche Telekom (Noel Wirzius)|
 | API summary | This API offers detailed insights into the customer's data usage status, including whether they have remaining data volume available and their current position within that volume allocation. It accurately determines whether the customer is nearing the beginning or the end of their allocated data volume, providing valuable information for managing data usage efficiently.|
 | Technical viability | The API should get information for a dedicated Sim-Card and also offer this in a subscription mode. The return value should not be a fixed value more an estimated indicator  (e.g. <200mb, <1Gb ...) |
 | Commercial viability | This API was requested by different content providers. It helps them to get more insights, how to deliver their traffic. | NO |
 | Validated in lab/productive environments? | Yes |
 | Validated with operators? | Yes |
 | Supporters in API Backlog Working Group | Vonage, Vodafone, Deutsche Telekom |