### PR TITLE
Update MAINTAINERS.MD

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,7 @@
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 
 * @TEF-RicardoSerr @jgarciahospital @NoelWirzius @caubut-charter
+
+# Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
+/CODEOWNERS @camaraproject/admins
+/MAINTAINERS.MD @camaraproject/admins

--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -1,9 +1,9 @@
-| Org                    | Name                                                |
-| -----------------------| ----------------------------------------------------|
-| Charter Comunications | Christopher Aubut |
-| Deutsche Telekom | Noel Wirzius |
-| GSMA | Mark Cornall |
-| Orange | Ludovic Robert |
-| Telefonica | Jorge Garcia |
-| Telefonica | Ricardo Serrano |
-| Vodafone | Eric Murray |
+| Org                    | Name                     | GitHub Username           |
+| -----------------------| -------------------------|---------------------------|
+| Charter Comunications | Christopher Aubut | caubut-charter |
+| Deutsche Telekom | Noel Wirzius | NoelWirzius |
+| GSMA | Mark Cornall | MarkCornall |
+| Orange | Ludovic Robert | bigludo7 |
+| Telefonica | Jorge Garcia | jgarciahospital |
+| Telefonica | Ricardo Serrano | TEF-RicardoSerr |
+| Vodafone | Eric Murray | eric-murray |


### PR DESCRIPTION
#### What type of PR is this?

* subproject management

#### What this PR does / why we need it:

To execute https://github.com/camaraproject/Governance/issues/134 we need the GitHub Usernames of all Maintainers in MAINTAINERS.MD. For that purpose a new column has been added.

In addition the TSC requested to use this opportunity to review the list of Maintainers if they are still current (e.g. the Maintainer still active, with the listed affiliation, etc). Please consider this in your review.

The PR adds also the following lines at the end of CODEOWNER file to ensure that CAMARA Admins are going forward involved in all changes of the both files and can keep the teams in the CAMARA Project organisation in sync:

```
# Owners of the CODEOWNER and Maintainer.md files are the admins of CAMARA (to allow them to keep the teams within the CAMARA organization in sync in case of changes)
/CODEOWNERS @camaraproject/admins
/MAINTAINERS.MD @camaraproject/admins
```

#### Which issue(s) this PR fixes:

Non (related issue is https://github.com/camaraproject/Governance/issues/134)

#### Special notes for reviewers:


