### PR TITLE
New APIproposal_ReceiveSMS - Totogi

### DIFF
--- a/documentation/API proposals/APIproposal_ReceiveSMS_Totogi.md
+++ b/documentation/API proposals/APIproposal_ReceiveSMS_Totogi.md
@@ -1,0 +1,12 @@
+| **Field** | Description | 
+| ---- | ----- |
+| API family name | Receive SMS API |
+| API family owner | Totogi |
+| API summary | This API supports sending responses to incoming SMS messages, enabling businesses to maintain continuous conversations with their customers. It is essential for enterprises looking to leverage SMS as a dynamic two-way communication channel.Businesses can use the API to offer real-time SMS support, answering queries, resolving issues, and providing information directly in response to customer messages, including the use of chat bots. Companies can engage customers in surveys or feedback sessions via SMS, responding to their inputs with follow-up questions or acknowledgments, enriching the customer experience and gathering valuable insights.It can also be used as a way of compliance with regulations by enabling an easy opt-out mechanism. Customers can reply with specific keywords (e.g., 'STOP') to unsubscribe from SMS communications, with the system automatically processing these requests. |
+| Technical viability | This API requires prior registration with the SMS service provider, as outlined in the Send SMS proposal (document #349), and is intended for outbound responses from businesses to customers. | 
+| Commercial viability | This is an opportunity for operators to enter or expand their presence in the CPaaS sector, a market that has seen considerable growth due to the increasing demand for integrated communication solutions by small, medium and large enterprises. The market already features a range of CPaaS platforms such as Twilio, Infobip, Vonage and others, which offer similar capabilities. However, operators can create a competitive edge with their existing network infrastructure and customer base, opening up additional revenue streams.|
+| YAML code available? | NO. |
+| Validated in lab/productive environments? | NO. |
+| Validated with real customers? | NO. |
+| Validated with operators? | NO. |
+| Supporters in API Backlog Working Group | List of supporters. <br><em> NOTE: That shall be added by the Working Group. </em> |


### PR DESCRIPTION
In order to migrate to new repo the old PR existing in WorkingGroups Repo.

This PR overseeds: https://github.com/camaraproject/WorkingGroups/pull/391

Fixes #18 

First comment bellow:

> In reference with issue [camaraproject/APIBacklog#18](https://github.com/camaraproject/APIBacklog/issues/18). This PR contains the proposal template for the ReceiveSMS API.