### PR TITLE
Add Vodafone as supporter for Dynamic Predictive Connectivity Data API

### DIFF
--- a/documentation/API proposals/APIProposal_Dynamic Dynamic Predictive Connectivity Data_Telefonica.md
+++ b/documentation/API proposals/APIProposal_Dynamic Dynamic Predictive Connectivity Data_Telefonica.md
@@ -9,4 +9,4 @@
 | Validated in lab/productive environments? | YES <br>Lab environment |
 | Validated with real customers? | YES|
 | Validated with operators? | NO |
-| Supporters in API Backlog Working Group | Telefonica, DT|
+| Supporters in API Backlog Working Group | Telefonica, DT, Vodafone|


### PR DESCRIPTION
#### What type of PR is this?
* documentation
* subproject management

#### What this PR does / why we need it:
Adds Vodafone as a supporter of the Dynamic Predictive Connectivity Data API

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # N/A

#### Special notes for reviewers:
None


#### Changelog input

```
 release-note
 - Add Vodafone as supporter for Dynamic Predictive Connectivity Data API
```

#### Additional documentation 
None