### PR TITLE
Update APIbacklog.md - name change of ApplicationProfiles

### DIFF
--- a/documentation/APIbacklog.md
+++ b/documentation/APIbacklog.md
@@ -733,8 +733,8 @@ This is a live doc that captures the status of all the APIs which have been form
       </td>
       <td><ul><li>TSC Approved (2025/20/02)</li></ul></td>
       <td>
-        <a href="https://github.com/camaraproject/ApplicationProfile">ApplicationProfile</a>
-        <a href="https://github.com/camaraproject/ApplicationProfile/blob/main/MAINTAINERS.MD">Maintainers</a>
+        <a href="https://github.com/camaraproject/ApplicationProfiles">ApplicationProfiles</a>
+        <a href="https://github.com/camaraproject/ApplicationProfiles/blob/main/MAINTAINERS.MD">Maintainers</a>
       </td>
       <td>N/A</td>
     </tr>


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* documentation

#### What this PR does / why we need it:

Name of repository "ApplicationProfile" got changed to "ApplicationProfiles"

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # na
But see https://github.com/camaraproject/APIBacklog/issues/181 for the reasoning of the name change.

#### Special notes for reviewers:

Shouldn't create a conflict with #194, so can be merged independently.
