### PR TITLE
[backlog table]: Update backlog table as until June 12, 25

### DIFF
--- a/documentation/APIbacklog.md
+++ b/documentation/APIbacklog.md
@@ -1019,6 +1019,16 @@ This is a live doc that captures the status of all the APIs which have been form
       <td>Pending</td>
       <td>N/A</td>
     </tr>
+      <tr>
+      <th>Sponsored Data</th>
+      <td>Telecom Argentina S.A.*<div></div></td>
+      <td>
+        <a href="https://github.com/camaraproject/APIBacklog/pull/224">Template</a><div>2024/11/26</div>
+      </td>
+      <td><ul><li>Under backlog discussion</li></ul></td>
+      <td>Pending</td>
+      <td>N/A</td>
+    </tr>
   </tbody>
 </table>
 

--- a/documentation/APIbacklog.md
+++ b/documentation/APIbacklog.md
@@ -71,7 +71,7 @@ This is a live doc that captures the status of all the APIs which have been form
       </td>
     </tr>
     <tr>
-      <th>MEC Management</th>
+      <th>Edge Application Management</th>
       <td>Telefónica*</td>
       <td>N/A<br>N/A</td>
       <td><ul><li>TSC Approved (N/A)</li></ul></td>

--- a/documentation/APIbacklog.md
+++ b/documentation/APIbacklog.md
@@ -979,8 +979,7 @@ This is a live doc that captures the status of all the APIs which have been form
       <td>Pending</td>
       <td>N/A</td>
     </tr>
-  <tr>
-
+    <tr>
       <th>Fixed Lines in Location</th>
       <td>Telefonica*<div></div></td>
       <td>

--- a/documentation/APIbacklog.md
+++ b/documentation/APIbacklog.md
@@ -939,7 +939,10 @@ This is a live doc that captures the status of all the APIs which have been form
         <a href="https://github.com/camaraproject/APIBacklog/issues/205">Template</a><div>2024/11/26</div>
       </td>
       <td><ul><li>TSC Approved (2025/06/05)</li></ul></td>
-      <td>Pending</td>
+      <td>
+        <a href="https://github.com/camaraproject/MultiPointVPN">MultiPointVPN</a>
+        <a href="https://github.com/camaraproject/MultiPointVPN/blob/main/MAINTAINERS.MD">Maintainers</a>
+      </td>   
       <td>N/A</td>
     </tr>
     <tr>

--- a/documentation/APIbacklog.md
+++ b/documentation/APIbacklog.md
@@ -245,8 +245,8 @@ This is a live doc that captures the status of all the APIs which have been form
       </td>
       <td><ul><li>TSC Approved (2023/09/07)</li></ul></td>
       <td>
-        <a href="https://github.com/camaraproject/KnowYourCustomer">KnowYourCustomer</a><br>
-        <a href="https://github.com/camaraproject/KnowYourCustomer/blob/main/MAINTAINERS.MD">Maintainers</a>
+        <a href="https://github.com/camaraproject/KnowYourCustomerMatch">KnowYourCustomerMatch</a><br>
+        <a href="https://github.com/camaraproject/KnowYourCustomerMatch/blob/main/MAINTAINERS.MD">Maintainers</a>
       </td>
       <td>
         <a href="https://github.com/camaraproject/KnowYourCustomer/releases/tag/r2.2">v0.3.0 spring25</a><div>2025/03/07</div>
@@ -260,8 +260,8 @@ This is a live doc that captures the status of all the APIs which have been form
       </td>
       <td><ul><li>TSC Approved (2023/09/07)</li></ul></td>
       <td>
-        <a href="https://github.com/camaraproject/KnowYourCustomer">KnowYourCustomer</a><br>
-        <a href="https://github.com/camaraproject/KnowYourCustomer/blob/main/MAINTAINERS.MD">Maintainers</a>
+        <a href="https://github.com/camaraproject/KnowYourCustomerFill-in">KnowYourCustomerFill-in</a><br>
+        <a href="https://github.com/camaraproject/KnowYourCustomerFill-in/blob/main/MAINTAINERS.MD">Maintainers</a>
       </td>
       <td>
         <a href="https://github.com/camaraproject/KnowYourCustomer/releases/tag/r2.2">v0.3.0 spring25</a><div>2025/03/07</div>
@@ -346,8 +346,8 @@ This is a live doc that captures the status of all the APIs which have been form
       </td>
       <td><ul><li>TSC Approved (2023/11/16)</li></ul></td>
       <td>
-        <a href="https://github.com/camaraproject/KnowYourCustomer">KnowYourCustomer</a><br>
-        <a href="https://github.com/camaraproject/KnowYourCustomer/blob/main/MAINTAINERS.MD">Maintainers</a>
+        <a href="https://github.com/camaraproject/KnowYourCustomerAgeVerification">KnowYourCustomerAgeVerification</a><br>
+        <a href="https://github.com/camaraproject/KnowYourCustomerAgeVerification/blob/main/MAINTAINERS.MD">Maintainers</a>
       </td>
       <td>
         <a href="https://github.com/camaraproject/KnowYourCustomer/releases/tag/r2.2">v0.1.0 spring25</a><br>2025/03/07
@@ -883,6 +883,29 @@ This is a live doc that captures the status of all the APIs which have been form
         <a href="https://github.com/camaraproject/APIBacklog/blob/main/documentation/API%20proposals/APIproposal_Voice%20Notification_chinaunicom.md">Template</a><div>2024/12/13</div>
       </td>
       <td><ul><li>TSC Approved (2025/04/17) </li></ul></td>
+      <td>
+        <a href="https://github.com/camaraproject/VoiceNotification">VoiceNotification</a>
+        <a href="https://github.com/camaraproject/VoiceNotification/blob/main/MAINTAINERS.MD">Maintainers</a>
+      </td>     
+      <td>N/A</td>
+    </tr>
+    <tr>
+      <th>Voice Verification Code</th>
+      <td>China Unicom*<div></div></td>
+      <td>
+        <a href="https://github.com/camaraproject/APIBacklog/pull/161">Template</a><div>2024/12/13</div>
+      </td>
+      <td><ul><li>TSC Approved (2025/06/05)</li></ul></td>
+      <td>Pending</td>
+      <td>N/A</td>
+    </tr>
+    <tr>
+      <th>Multi Point VPN</th>
+      <td>Infosys Ltd*<div></div></td>
+      <td>
+        <a href="https://github.com/camaraproject/APIBacklog/issues/205">Template</a><div>2024/11/26</div>
+      </td>
+      <td><ul><li>TSC Approved (2025/06/05)</li></ul></td>
       <td>Pending</td>
       <td>N/A</td>
     </tr>
@@ -957,26 +980,6 @@ This is a live doc that captures the status of all the APIs which have been form
       <td>N/A</td>
     </tr>
     <tr>
-      <th>Fixed Lines in Location</th>
-      <td>Telefonica*<div></div></td>
-      <td>
-        <a href="https://github.com/camaraproject/APIBacklog/pull/92">Template</a><div>2024/10/01</div>
-      </td>
-      <td><ul><li>Under backlog discussion</li></ul></td>
-      <td>Pending</td>
-      <td>N/A</td>
-    </tr>
-    <tr>
-      <th>Line Eligibility for Carrier Billing API</th>
-      <td>Telefonica*<div></div></td>
-      <td>
-        <a href="https://github.com/camaraproject/APIBacklog/pull/94">Template</a><div>2024/10/01</div>
-      </td>
-      <td><ul><li>Under backlog discussion</li></ul></td>
-      <td>Pending</td>
-      <td>N/A</td>
-    </tr>
-    <tr>
       <th>SIM Historical Information</th>
       <td>China Unicom*<div></div></td>
       <td>
@@ -1007,30 +1010,10 @@ This is a live doc that captures the status of all the APIs which have been form
       <td>N/A</td>
     </tr>
     <tr>
-      <th>Voice Verification Code</th>
-      <td>China Unicom*<div></div></td>
-      <td>
-        <a href="https://github.com/camaraproject/APIBacklog/pull/161">Template</a><div>2024/12/13</div>
-      </td>
-      <td><ul><li>Under backlog discussion</li></ul></td>
-      <td>Pending</td>
-      <td>N/A</td>
-    </tr>
-    <tr>
       <th>IdentityAndConsentManagement</th>
       <td>Cellcard*<div></div></td>
       <td>
         <a href="https://github.com/camaraproject/APIBacklog/pull/166">Template</a><div>2024/11/26</div>
-      </td>
-      <td><ul><li>Under backlog discussion</li></ul></td>
-      <td>Pending</td>
-      <td>N/A</td>
-    </tr>
-    <tr>
-      <th>Multi Point VPN</th>
-      <td>Infosys Ltd*<div></div></td>
-      <td>
-        <a href="https://github.com/camaraproject/APIBacklog/issues/205">Template</a><div>2024/11/26</div>
       </td>
       <td><ul><li>Under backlog discussion</li></ul></td>
       <td>Pending</td>

--- a/documentation/APIbacklog.md
+++ b/documentation/APIbacklog.md
@@ -979,6 +979,26 @@ This is a live doc that captures the status of all the APIs which have been form
       <td>Pending</td>
       <td>N/A</td>
     </tr>
+  <tr>
+      <th>Fixed Lines in Location</th>
+      <td>Telefonica*<div></div></td>
+      <td>
+        <a href="https://github.com/camaraproject/APIBacklog/pull/92">Template</a><div>2024/10/01</div>
+      </td>
+      <td><ul><li>Under backlog discussion</li></ul></td>
+      <td>Pending</td>
+      <td>N/A</td>
+    </tr>
+    <tr>
+      <th>Line Eligibility for Carrier Billing API</th>
+      <td>Telefonica*<div></div></td>
+      <td>
+        <a href="https://github.com/camaraproject/APIBacklog/pull/94">Template</a><div>2024/10/01</div>
+      </td>
+      <td><ul><li>Under backlog discussion</li></ul></td>
+      <td>Pending</td>
+      <td>N/A</td>
+    </tr>
     <tr>
       <th>SIM Historical Information</th>
       <td>China Unicom*<div></div></td>

--- a/documentation/APIbacklog.md
+++ b/documentation/APIbacklog.md
@@ -82,6 +82,39 @@ This is a live doc that captures the status of all the APIs which have been form
       <td>No release</td>
     </tr>
     <tr>
+      <th>Optimal Edge Discovery</th>
+      <td>Telefónica, 5GFF, Capgemini, EdgeXR, Orange*</td>
+      <td>N/A<br>N/A</td>
+      <td><ul><li>TSC Approved (N/A)</li></ul></td>
+      <td>
+        <a href="https://github.com/camaraproject/OptimalEdgeDiscovery">OptimalEdgeDiscovery</a><br>
+        <a href="https://github.com/camaraproject/OptimalEdgeDiscovery/blob/main/MAINTAINERS.MD">Maintainers</a>
+      </td>
+      <td>No release</td>
+    </tr>
+    <tr>
+      <th>Application Endpoint Discovery</th>
+      <td>Telefónica, 5GFF, Capgemini, EdgeXR, Orange*</td>
+      <td>N/A<br>N/A</td>
+      <td><ul><li>TSC Approved (N/A)</li></ul></td>
+      <td>
+        <a href="https://github.com/camaraproject/ApplicationEndpointDiscovery">ApplicationEndpointDiscovery</a><br>
+        <a href="https://github.com/camaraproject/ApplicationEndpointDiscovery/blob/main/MAINTAINERS.MD">Maintainers</a>
+      </td>
+      <td>No release</td>
+    </tr>
+    <tr>
+      <th>Application Endpoint Registration</th>
+      <td>Telefónica, 5GFF, Capgemini, EdgeXR, Orange*</td>
+      <td>N/A<br>N/A</td>
+      <td><ul><li>TSC Approved (N/A)</li></ul></td>
+      <td>
+        <a href="https://github.com/camaraproject/ApplicationEndpointRegistration">ApplicationEndpointRegistration</a><br>
+        <a href="https://github.com/camaraproject/ApplicationEndpointRegistration/blob/main/MAINTAINERS.MD">Maintainers</a>
+      </td>
+      <td>No release</td>
+    </tr>
+    <tr>
       <th>Device Location</th>
       <td>Deutsche Telekom*, Orange, Telefónica, Vodafone</td>
       <td>N/A<br>2022/01/11</td>
@@ -1039,7 +1072,7 @@ This is a live doc that captures the status of all the APIs which have been form
       <td>Pending</td>
       <td>N/A</td>
     </tr>
-      <tr>
+    <tr>
       <th>Sponsored Data</th>
       <td>Telecom Argentina S.A.*<div></div></td>
       <td>

--- a/documentation/APIbacklog.md
+++ b/documentation/APIbacklog.md
@@ -980,6 +980,7 @@ This is a live doc that captures the status of all the APIs which have been form
       <td>N/A</td>
     </tr>
   <tr>
+
       <th>Fixed Lines in Location</th>
       <td>Telefonica*<div></div></td>
       <td>

--- a/documentation/APIbacklog.md
+++ b/documentation/APIbacklog.md
@@ -929,7 +929,10 @@ This is a live doc that captures the status of all the APIs which have been form
         <a href="https://github.com/camaraproject/APIBacklog/pull/161">Template</a><div>2024/12/13</div>
       </td>
       <td><ul><li>TSC Approved (2025/06/05)</li></ul></td>
-      <td>Pending</td>
+      <td>
+        <a href="https://github.com/camaraproject/VoiceVerificationCode">VoiceVerificationCode</a>
+        <a href="https://github.com/camaraproject/VoiceVerificationCode/blob/main/MAINTAINERS.MD">Maintainers</a>
+      </td>  
       <td>N/A</td>
     </tr>
     <tr>


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation

#### What this PR does / why we need it:

Update of the backlog table with the latest updates of the TSC and the backlog group until June 12, 25.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes:
- https://github.com/camaraproject/APIBacklog/issues/157 - Voice Notification API Proposal
- https://github.com/camaraproject/APIBacklog/issues/213 - Split KnowYourCustomer SP repo
- https://github.com/camaraproject/APIBacklog/issues/205 - Multi Point VPN API Proposal
- https://github.com/camaraproject/APIBacklog/issues/160 - Voice Verification Code API Proposal
- https://github.com/camaraproject/APIBacklog/issues/222 - Split EdgeCloud repo
- https://github.com/camaraproject/APIBacklog/issues/223 - Sponsored Data

#### Special notes for reviewers:

Decisions taken in the last TSC and API Backlog WG decisions, review last minutes of both meetings.

#### Changelog input

```
 release-note
Update states for Voice Notification API Proposal, Split KnowYourCustomer SP repo, Multi Point VPN API Proposal, and Voice Verification Code API Proposal

```

#### Additional documentation 

N/A

```
docs

```
