### PR TITLE
Add issue template for new API proposals

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_api_proposal_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_api_proposal_template.md
@@ -1,0 +1,20 @@
+---
+name: 💡 API Proposal
+about: Propose a new API to be considered by CAMARA
+title: '[API Proposal] <insert API name>'
+labels: 'API Proposal'
+assignees: ''
+
+---
+
+**Description**  
+<!-- Provide a clear and concise description of the proposed API. What problem does it solve? -->
+
+**Use cases**  
+<!-- List the key use cases this API would support. Try to be concise and user-focused. -->
+
+**Related to**  
+<!-- Link to any related pull requests, issues, or previous proposals (e.g. #123 or https://github.com/...). -->
+
+**Supporting material**  
+<!-- Add any links to relevant documentation, diagrams, presentations, or other supporting content. -->


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature

#### What this PR does / why we need it:

This PR introduces a new GitHub issue template for API proposals.  
It standardizes the required fields (`Description`, `Use Cases`, `Related to`, `Supporting Material`) and applies the `API Proposal` label automatically.

This template will help streamline the submission process, ensuring consistency across all API proposals and improving visibility and traceability across the CAMARA project.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes https://github.com/camaraproject/APIBacklog/issues/225

#### Special notes for reviewers:

Please verify the relevance of the included fields in the template and suggest any improvements regarding clarity or completeness. 
 
Feedback on the structure and naming conventions is appreciated.

#### Changelog input

```
 release-note
Added new GitHub issue template for API proposals to improve consistency and visibility.
```

#### Additional documentation 

N/A

```
docs

```
