### PR TITLE
Update APIbacklog.md

### DIFF
--- a/documentation/APIbacklog.md
+++ b/documentation/APIbacklog.md
@@ -824,7 +824,7 @@ This is a live doc that captures the status of all the APIs which have been form
     </tr>
     <tr>
       <th>IoT Device Management</th>
-      <td>Verizon*<div></div></td>
+      <td>Verizon*, China Telecom*<div></div></td>
       <td>
         <a href="https://github.com/camaraproject/APIBacklog/blob/main/documentation/API%20proposals/APIproposal_IoTDeviceManagement_Verizon.md">Template</a><div>2024/04/26</div>
       </td>


### PR DESCRIPTION
Set China Telecom as owner of IoT Device Management API family

As the de facto owner since Q1 2025, China Telecom has driven the development of IoT Device Management APIs.

This commit formally assigns ownership to reflect ongoing contributions.

#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:
Make the backlog correctly reflect the API family owner of Iot Device Management project.



#### Which issue(s) this PR fixes:
None
<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #

#### Special notes for reviewers:



#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
