### PR TITLE
Remove point of Update of CAMARA presentation and website

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_tracker_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_tracker_template.md
@@ -43,7 +43,6 @@ assignees: ''
 - [ ] **Repository created** _(LF Admin via automation)_  
 - [ ] Add repository link to the API wiki page _(LF Admin)_  
 - [ ] Update `README.md` in the repository with API details _(API owner)_  
-- [ ] File issue in **Marketing repo** to update CAMARA website and presentation deck  
 - [ ] Update `APIBacklog.md` with status: `Onboarded`  
 - [ ] (Optional) Nominate initial **Maintainers** _(API owner)_  
 - [ ] (Optional) Submit PR to update `MAINTAINERS.md` and `CODEOWNERS`  


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation

#### What this PR does / why we need it:
Delete the point "Update of CAMARA presentation and website" from the onboarding tracker issues and its template. The agreement between CAMARA Marketing Working Group and GSMA Product Portfolio is that the APIs will be listed on the website only after there is a reviewed release candidate API version, so not as part of the Onboarding.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #190 (the proposal appeared in a comment)

#### Special notes for reviewers:

N/A

#### Changelog input

```
 release-note
Delete point of Marketing in onboarding-trackers
```

#### Additional documentation 

N/A

```
docs

```
