### PR TITLE
docs(api-backlog): require explicit CAMARA scope alignment in proposal templates

### DIFF
--- a/documentation/API-Scope-Enhancement-Template.md
+++ b/documentation/API-Scope-Enhancement-Template.md
@@ -1,6 +1,14 @@
 # API Scope Enhancement Template
-
 This template captures all the information that a partner should fill out when proposing a scope enhancement for an existing CAMARA API.
+
+> **Important**
+> Before submitting a scope enhancement, proposal owners shall review the CAMARA [Project Charter](https://github.com/camaraproject/Governance/blob/main/ProjectCharter.md), in particular the sections related to CAMARA scope.
+>
+> CAMARA scope is limited to telco APIs exposed as **customer-facing northbound APIs**. Only **Service APIs** and **Service Management APIs** are in scope. **Operate APIs** and **east-west / federation / roaming APIs** are out of scope.
+>
+> A scope enhancement requires API Backlog validation when it modifies the original scope of an existing API.
+>
+> If there is any doubt regarding scope fit or impact on the existing API, the proposal owner shall justify it explicitly in the sections below with reference to the Project Charter.
 
 ## API name  
 Name of the API or API family whose scope is proposed to be enhanced.  
@@ -14,6 +22,37 @@ Company submitting the API enhancement.
 
 ## Scope Enhancement summary  
 High level description / scope of the API or API family, and two or three examples of in-scope business cases.  
+
+## CAMARA scope alignment
+
+### Northbound API type  
+Select the CAMARA northbound API type for this proposal:
+- [ ] Service API
+- [ ] Service Management API
+
+### Scope fit with CAMARA  
+Explain why the enhanced scope remains in scope for CAMARA, with explicit reference to the [Project Charter](https://github.com/camaraproject/Governance/blob/main/ProjectCharter.md).
+
+### Telco capability exposed  
+Describe the telco network capability, or telco-supporting capability, that is abstracted / exposed by the proposed enhancement.
+
+### Overlap with existing CAMARA APIs  
+- [] The CAMARA API portfolio has been reviewed, and it has been confirmed that there is no overlap. 
+
+## Scope change justification
+
+### Why backlog validation is required  
+Explain how this proposal modifies the original scope of the API and why it therefore requires API Backlog validation.
+
+### Impact on the existing API scope  
+Explain how the current API scope would change. Indicate whether the proposal:
+- extends the existing API with new functionality,
+- adds a new API in the same repository,
+- requires a broader API family scope,
+- or may be better handled through a new repository.
+
+### Explicit out-of-scope items for this enhancement  
+List related capabilities, features, or functions that are explicitly out of scope for this enhancement.
 
 ## Technical viability  
 Identify the underlying network/cloud capabilities which are needed for the support of this API or API family, relating these capabilities to standards maturity.  

--- a/documentation/API-proposal-template.md
+++ b/documentation/API-proposal-template.md
@@ -1,6 +1,12 @@
 # API Proposal Template
 This template captures all the information that a partner should fill out when proposing a new API (or API family) to CAMARA.
 
+> **Important**
+> Before submitting a new API proposal, proposal owners shall review the CAMARA [Project Charter](https://github.com/camaraproject/Governance/blob/main/ProjectCharter.md), in particular the sections related to CAMARA scope.
+>
+> CAMARA scope is limited to telco APIs exposed as **customer-facing northbound APIs**. Only **Service APIs** and **Service Management APIs** are in scope. **Operate APIs** and **east-west / federation / roaming APIs** are out of scope.
+>
+> If there is any doubt regarding scope fit, the proposal owner shall justify it explicitly in the sections below with reference to the Project Charter.
 
 ### API family name  
 Name of the API or API family.
@@ -10,6 +16,28 @@ Company submitting the API proposal.
 
 ### API summary  
 High level description / scope of the API or API family, and two/three examples of in-scope business cases.
+
+### CAMARA scope alignment
+
+#### Northbound API type  
+Select the CAMARA northbound API type for this proposal:
+- [ ] Service API
+- [ ] Service Management API
+
+#### Scope fit with CAMARA  
+Explain why this proposal is in scope for CAMARA, with explicit reference to the [Project Charter](https://github.com/camaraproject/Governance/blob/main/ProjectCharter.md).
+
+#### Telco capability exposed  
+Describe the telco network capability, or telco-supporting capability, that is abstracted / exposed by this proposal.
+
+#### Overlap with existing CAMARA APIs  
+- [] The CAMARA API portfolio has been reviewed, and it has been confirmed that there is no overlap.  
+
+#### Explicit out-of-scope items for this proposal  
+List related capabilities, features, or functions that are explicitly out of scope for this proposal.
+
+#### Proposal owner declaration  
+- [ ] I confirm that this proposal has been reviewed against the current CAMARA Project Charter scope.
 
 ### Technical viability  
 Identify the underlying network/cloud capabilities which are needed for the support of this API or API family, relating these capabilities to standards maturity.  


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* documentation

#### What this PR does / why we need it:
This PR updates the API Proposal Template and the API Scope Enhancement Template to require explicit justification of CAMARA scope alignment at proposal submission time.

The goal is to reduce repeated backlog iterations on proposals that do not fit CAMARA scope from the beginning, by making proposal owners assess and document:
- how the proposal aligns with the CAMARA Project Charter,
- which CAMARA northbound API type it belongs to,
- why it is not an out-of-scope interface,
- and how it relates to existing CAMARA APIs.

For scope enhancements, the template also makes explicit why backlog validation is needed and how the proposed change impacts the scope of the existing API.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #308

#### Special notes for reviewers:
This PR does not change CAMARA scope itself.
It operationalizes the existing Project Charter requirements earlier in the API Backlog intake process.

The intention is to improve proposal quality and scope clarity before backlog discussion, not to introduce new governance rules.

#### Changelog input

```
 release-note
Update API Backlog proposal templates to require explicit CAMARA scope alignment justification for new proposals and scope enhancements.
```

#### Additional documentation 

```
docs
Update API Proposal and API Scope Enhancement templates to make CAMARA scope-fit assessment explicit at submission time.
```
